### PR TITLE
Add SerpAPI key configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,20 @@ O endpoint `api/outbound_webhook.php` agora exige um token de acesso informado v
 ```
 Defina `API_TOKEN` no `.env` para controlar o acesso.
 
+## Integração com SerpAPI
+
+1. **Obtenha a chave**
+   - Acesse [SerpAPI](https://serpapi.com) e crie uma conta gratuita.
+   - Copie sua *API Key* disponível no painel do usuário.
+2. **Ative o serviço na aplicação**
+   - No menu de configurações (`settings.php`), informe a chave no campo **Chave do SerpAPI**.
+   - Salve as alterações para que o worker possa utilizá-la.
+3. **Exemplo de uso**
+   ```php
+   $serpApiKey = get_setting($pdo, 'serpapi_key');
+   $query = urlencode('exemplo de empresa');
+   $url = "https://serpapi.com/search.json?q={$query}&engine=google&api_key={$serpApiKey}";
+   $response = file_get_contents($url);
+   ```
+   O retorno é um JSON com resultados de busca que podem ser utilizados para enriquecer dados de clientes.
+

--- a/migrations/add_linkedin_column.sql
+++ b/migrations/add_linkedin_column.sql
@@ -1,0 +1,3 @@
+-- Script de migração para adicionar coluna de perfil LinkedIn nos contatos
+ALTER TABLE client_contacts
+    ADD COLUMN linkedin_url VARCHAR(255) NULL AFTER info;

--- a/settings.php
+++ b/settings.php
@@ -109,6 +109,10 @@ $settings = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
                                 <input type="password" id="google_api_key" name="google_api_key" value="<?= htmlspecialchars($settings['google_api_key'] ?? '') ?>" class="mt-1 block w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
                             </div>
                             <div>
+                                <label for="serpapi_key" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chave do SerpAPI</label>
+                                <input type="password" id="serpapi_key" name="serpapi_key" value="<?= htmlspecialchars($settings['serpapi_key'] ?? '') ?>" class="mt-1 block w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                            </div>
+                            <div>
                                 <label for="enrichment_service_api_key" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chave do Serviço de Enriquecimento</label>
                                 <input type="password" id="enrichment_service_api_key" name="enrichment_service_api_key" value="<?= htmlspecialchars($settings['enrichment_service_api_key'] ?? '') ?>" class="mt-1 block w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
                             </div>


### PR DESCRIPTION
## Summary
- capture SerpAPI API key in settings page
- document SerpAPI integration and usage in README
- provide SQL migration for LinkedIn contact column

## Testing
- `php -l settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68b74aacbc688321958590c6dbdbe0cf