### PR TITLE
Add FastAPI LinkedIn service and SERPAPI configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_NAME=your_database
+DB_USER=your_user
+DB_PASS=your_password
+API_TOKEN=change_me
+SERPAPI_KEY=your_serpapi_key

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ php workers/enrichment_worker.php
 ```
 Ele buscará jobs pendentes, consultará APIs externas e salvará os resultados.
 
+## Serviço LinkedIn (FastAPI)
+
+Um pequeno serviço em FastAPI disponível em `linkedin_service/` oferece integração com a SerpAPI para buscas de perfis. Para executá-lo em modo de desenvolvimento:
+
+```bash
+cd linkedin_service
+uvicorn main:app --reload
+```
+
+Garanta que o PHP possa acessar `http://localhost:8000` (ajuste regras de firewall ou proxy conforme necessário).
+
 ## Endpoints Principais
 
 - `GET /api/get_clients.php` – lista clientes e estatísticas para o dashboard

--- a/linkedin_service/Dockerfile
+++ b/linkedin_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/linkedin_service/main.py
+++ b/linkedin_service/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import os
+import requests
+
+app = FastAPI()
+
+SERPAPI_KEY = os.getenv("SERPAPI_KEY")
+
+class LookupRequest(BaseModel):
+    query: str
+
+@app.post("/search")
+def search_linkedin(req: LookupRequest):
+    if not SERPAPI_KEY:
+        raise HTTPException(status_code=500, detail="SERPAPI_KEY not configured")
+    params = {
+        "engine": "google",
+        "q": f"site:linkedin.com/in {req.query}",
+        "api_key": SERPAPI_KEY,
+    }
+    resp = requests.get("https://serpapi.com/search", params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()

--- a/linkedin_service/requirements.txt
+++ b/linkedin_service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+requests

--- a/settings.php
+++ b/settings.php
@@ -112,6 +112,10 @@ $settings = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
                                 <label for="enrichment_service_api_key" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chave do Serviço de Enriquecimento</label>
                                 <input type="password" id="enrichment_service_api_key" name="enrichment_service_api_key" value="<?= htmlspecialchars($settings['enrichment_service_api_key'] ?? '') ?>" class="mt-1 block w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
                             </div>
+                            <div>
+                                <label for="serpapi_key" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chave do SerpAPI</label>
+                                <input type="password" id="serpapi_key" name="serpapi_key" value="<?= htmlspecialchars($settings['serpapi_key'] ?? '') ?>" class="mt-1 block w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- add FastAPI-based `linkedin_service` with SerpAPI integration
- expose `SERPAPI_KEY` setting in PHP and `.env`
- document how to run the new service via `uvicorn`

## Testing
- `php -l settings.php`
- `python -m py_compile linkedin_service/main.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b74aa86cfc8321ab23ede0fde7a6a1